### PR TITLE
V0.3.5 alpha

### DIFF
--- a/.github/workflow/testing.yml
+++ b/.github/workflow/testing.yml
@@ -1,4 +1,5 @@
 name: Unit Testing
+on: [push, pull_request]
 jobs:
   my-job:
     name: breadroll Test Suite

--- a/.github/workflow/testing.yml
+++ b/.github/workflow/testing.yml
@@ -1,5 +1,10 @@
 name: Unit Testing
-on: [push, pull_request]
+on:  
+  push:
+  pull_request:
+    branches:
+      - main
+
 jobs:
   my-job:
     name: breadroll Test Suite

--- a/.github/workflow/testing.yml
+++ b/.github/workflow/testing.yml
@@ -1,0 +1,15 @@
+name: Unit Testing
+jobs:
+  my-job:
+    name: breadroll Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      # ...
+      - uses: actions/checkout@v3
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.22 
+
+      # run any `bun` or `bunx` command
+      - run: bun install
+      - run: bun test

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ we suggest you use it with some caution, as some unexpected behaviors can be pre
 <br/>
 
 - **Fast**: breadroll is built on Bun, the all-in-one Javascript runtime built for speed
-- **File I/O**: With current support for local data sources, **remote sources support** for `https`
+- **File I/O**: With current support for local data sources, **remote sources support** currently include - `https`
 - **Easy-to-use**: Compose queries using filter keywords that reads like English and are easy to comprehend
 
 ---
@@ -66,8 +66,8 @@ console.log(values)
 breadroll makes it easy to work with remote data sources with current support for fetching over `https`. With other remote data sources on the roadmap.
 
 ```typescript
-const df: Dataframe = await csv.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/main/test/data/test.csv");
-const selected: Dataframe = df..select(["class", "age", "hemo", "sc", "al", "bp"]);
+const df: Dataframe = await csv.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/.../ds_salaries.csv");
+const selected: Dataframe = df.select(["job_title", "salary", "salary_currency", "salary_in_usd"]);
 ```
 
 ### **Filtering**

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/devsgnr/breadroll/v0.3.1/docs/docs/assets/png/breadroll_brand.png" />
-</div>
+breadroll 🥟 The lightweight application toolkit for data analysis and data processing operations in JavaScript
 
-<br/><br/>
-
-<p align="center">Breadroll, is a simple lightweight application library for parsing csv, tsv, and other delimited files, performing EDA (exploratory data analysis), and data processing operations on multivariate datasets. Think pandas but written in Typescript and developed on the <a href="https://bun.sh" target="_blank">Bun</a> Runtime.</p>
-
-<p align="center">⚠️ This library is experimental and is still in active development. Although we make sure each version is tested throughly,
-we suggest you use it with some caution, as some unexpected behaviors can be present.</p>
+---
 
 <br/>
 
-- **Fast**: Breadroll is built on Bun, the all-in-one Javascript runtime built for speed
-- **File I/O**: With current support for local data sources, **remote sources support coming soon**
+![](https://raw.githubusercontent.com/devsgnr/breadroll/v0.3.1/docs/docs/assets/png/breadroll_brand.png)
+
+
+breadroll 🥟 is a simple lightweight application toolkit for parsing csv, tsv, and other delimited files, performing EDA (exploratory data analysis), and data processing operations on multivariate datasets. Think pandas but written in Typescript and developed on the [Bun](https://bun.sh) Runtime.
+
+⚠️ This library is experimental and is still in active development. Although we make sure each version is tested throughly,
+we suggest you use it with some caution, as some unexpected behaviors can be present.
+
+<br/>
+
+- **Fast**: breadroll is built on Bun, the all-in-one Javascript runtime built for speed
+- **File I/O**: With current support for local data sources, **remote sources support** for `https`
 - **Easy-to-use**: Compose queries using filter keywords that reads like English and are easy to comprehend
 
 ---
@@ -28,7 +31,7 @@ System Requirements:
 ---
 
 #### Bun
-Breadroll is built on and optimized for Bun.js. You can install Bun by running the following
+breadroll is built on and optimized for Bun.js. You can install Bun by running the following
 ```bash
 curl https://bun.sh/install | bash
 ```
@@ -36,22 +39,35 @@ create a new Bun project by running
 ```bash
 bun init
 ```
-then you can now install **Breadroll** using
+then you can now install **breadroll** using
 ```bash
 bun add breadroll
 ```
 ---
 
 ### **Easy API**
-Breadroll provides an easy to use API that gets you from zero to data processing in no time, with lazy loading of these delimited files via Bun's File I/O `Bun.file()`, the file parsed based on the `DataframeReadOptions`, and convert into a `Dataframe`, and easily read out the content of the Dataframe using `.value`.
+breadroll provides an easy to use API that gets you from zero to data processing in no time, with lazy loading of these delimited files via Bun's File I/O `Bun.file()`, the file parsed based on the `DataframeReadOptions`, and convert into a `Dataframe`, and easily read out the content of the Dataframe using `.value`.
 
 ```typescript
-const file: Breadroll = new Breadroll({ header: true, delimiter: "," });
-const df: Dataframe = await file.open.local("./data/ds_salaries.csv");
+const csv: Breadroll = new Breadroll({ header: true, delimiter: "," });
+```
+
+Example: From one instance example above, you can open multiple `csv` files
+
+```typescript
+const df: Dataframe = await csv.open.local("./data/ds_salaries.csv");
 const selected: Dataframe = df.select(["job_title", "salary", "salary_currency", "salary_in_usd"]);
 const values: Array<ObjectType> = selected.values
 
 console.log(values)
+```
+
+### **Remote Data Sources**
+breadroll makes it easy to work with remote data sources with current support for fetching over `https`. With other remote data sources on the roadmap.
+
+```typescript
+const df: Dataframe = await csv.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/main/test/data/test.csv");
+const selected: Dataframe = df..select(["class", "age", "hemo", "sc", "al", "bp"]);
 ```
 
 ### **Filtering**

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### **January 25th, 2024 - v0.3.5-alpha**
+
+- `Breadroll.open.https(url: string, headers?: Headers): Promise<Dataframe>` This function fetches and return a file via a URL over https, with a default `GET` method, with optional provision for custom headers
+
 ### **January 20th, 2024 - v0.3.1**
 
 - `Dataframe.select(keys: Array<string>): Dataframe` This function return a new Dataframe with only the desired rows, ie. rows with the specified labels

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,7 +10,7 @@ hide:
 breadroll 🥟 is a simple lightweight application library for parsing csv, tsv, and other delimited files, performing EDA (exploratory data analysis), and data processing operations on multivariate datasets. Think pandas but written in Typescript and developed on the [Bun](https://bun.sh) Runtime.
 
 - **Fast**: breadroll is built on Bun, the all-in-one Javascript runtime built for speed
-- **File I/O**: With current support for local data sources, **remote sources support** for `https`
+- **File I/O**: With current support for local data sources, **remote sources support** currently include - `https`
 - **Easy-to-use**: Compose queries using filter keywords that reads like English and are easy to comprehend
 
 
@@ -68,7 +68,7 @@ console.log(values)
 breadroll makes it easy to work with remote data sources with current support for fetching over `https`, with other remote data sources on the roadmap.
 
 ```typescript
-const df: Dataframe = await csv.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/main/test/data/ds_salaries.csv");
+const df: Dataframe = await csv.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/.../ds_salaries.csv");
 const selected: Dataframe = df..select(["job_title", "salary", "salary_currency", "salary_in_usd"]);
 ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -5,15 +5,13 @@ hide:
 
 # Home
 
-<div>
-  <img align="center" src="./assets/png/breadroll_brand.png" />
-</div>
+![](./assets/png/breadroll_brand.png)
 
-Breadroll.js, is a simple lightweight application library for parsing csv, tsv, and other delimited files, performing EDA (exploratory data analysis), and data processing operations on multivariate datasets. Think pandas but written in Typescript and developed on the [Bun](https://bun.sh) Runtime.
+breadroll 🥟 is a simple lightweight application library for parsing csv, tsv, and other delimited files, performing EDA (exploratory data analysis), and data processing operations on multivariate datasets. Think pandas but written in Typescript and developed on the [Bun](https://bun.sh) Runtime.
 
-- **Fast**: Breadroll is built on Bun, the all-in-one Javascript runtime built for speed
-- **File I/O**: With current support for local data sources, **remote sources support coming soon**
-- **Easy-to-use**: Compose queries using filter keywords that reads like English and are easy to comprehend.
+- **Fast**: breadroll is built on Bun, the all-in-one Javascript runtime built for speed
+- **File I/O**: With current support for local data sources, **remote sources support** for `https`
+- **Easy-to-use**: Compose queries using filter keywords that reads like English and are easy to comprehend
 
 
 !!! warning "Experimental"
@@ -47,17 +45,31 @@ bun add breadroll
 ---
 
 ### **Easy API**
-Breadroll provides an easy to use API that gets you from zero to data processing in no time, with lazy loading of these delimited files via Bun's File I/O `Bun.file()`, the file parsed based on the `DataframeReadOptions`, and convert into a `Dataframe`, and easily read out the content of the Dataframe using `.value`.
+breadroll provides an easy to use API that gets you from zero to data processing in no time, with lazy loading of these delimited files via Bun's File I/O `Bun.file()`, the file parsed based on the `DataframeReadOptions`, and convert into a `Dataframe`, and easily read out the content of the Dataframe using `.value`.
 ???+ note
 
     The dataset used in these example code snippets was gotten from Kaggle; [Employee Salaries for different job roles](https://www.kaggle.com/datasets/inductiveanks/employee-salaries-for-different-job-roles)
+
 ```typescript
-const file: Breadroll = new Breadroll({ header: true, delimiter: "," });
-const df: Dataframe = await file.open.local("./data/ds_salaries.csv");
+const csv: Breadroll = new Breadroll({ header: true, delimiter: "," });
+```
+
+Example: From one instance example above, you can open multiple `csv` files
+
+```typescript
+const df: Dataframe = await csv.open.local("./data/ds_salaries.csv");
 const selected: Dataframe = df.select(["job_title", "salary", "salary_currency", "salary_in_usd"]);
 const values: Array<ObjectType> = selected.values
 
 console.log(values)
+```
+
+### **Remote Data Sources**
+breadroll makes it easy to work with remote data sources with current support for fetching over `https`, with other remote data sources on the roadmap.
+
+```typescript
+const df: Dataframe = await csv.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/main/test/data/ds_salaries.csv");
+const selected: Dataframe = df..select(["job_title", "salary", "salary_currency", "salary_in_usd"]);
 ```
 
 ### **Filtering**

--- a/docs/docs/reference/Breadroll/https.md
+++ b/docs/docs/reference/Breadroll/https.md
@@ -2,7 +2,7 @@
 title: .open.https
 ---
 #### `Breadroll.open.https(...)`
-This function fetchs and return a file via a URL over https, with a default `GET` method, with optional provision for custom headers
+This function fetches and return a file via a URL over https, with a default `GET` method, with optional provision for custom headers
 
 Parameter
 

--- a/docs/docs/reference/Breadroll/https.md
+++ b/docs/docs/reference/Breadroll/https.md
@@ -10,6 +10,6 @@ Parameter
 - `header?:` [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) - add custom headers to the HTTP request
 
 ```typescript
-const df: Dataframe = await csv.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/main/test/data/test.csv");
-const selected: Dataframe = df.select(["class", "age", "hemo", "sc", "al", "bp"]);
+const df: Dataframe = await csv.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/.../ds_salaries.csv");
+const selected: Dataframe = df.select(["job_title", "salary", "salary_currency", "salary_in_usd"]);
 ```

--- a/docs/docs/reference/Breadroll/https.md
+++ b/docs/docs/reference/Breadroll/https.md
@@ -1,0 +1,15 @@
+---
+title: .open.https
+---
+#### `Breadroll.open.https(...)`
+This function fetchs and return a file via a URL over https, with a default `GET` method
+
+Parameter
+
+- `url: string` - the remote location of the file.
+- `header?:` [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) - add custom headers to the HTTP request
+
+```typescript
+const df: Dataframe = await csv.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/main/test/data/test.csv");
+const selected: Dataframe = df.select(["class", "age", "hemo", "sc", "al", "bp"]);
+```

--- a/docs/docs/reference/Breadroll/https.md
+++ b/docs/docs/reference/Breadroll/https.md
@@ -2,7 +2,7 @@
 title: .open.https
 ---
 #### `Breadroll.open.https(...)`
-This function fetchs and return a file via a URL over https, with a default `GET` method
+This function fetchs and return a file via a URL over https, with a default `GET` method, with optional provision for custom headers
 
 Parameter
 

--- a/docs/docs/reference/Breadroll/local.md
+++ b/docs/docs/reference/Breadroll/local.md
@@ -9,7 +9,7 @@ Parameter
 - `filepath: string` - the location of the file.
 
 ```typescript
-const file: Breadroll = new Breadroll({ header: true, delimiter: "," });
-const df: Dataframe = await file.open.local("./test/data/adult.data");
-const filtered = df.filter("workclass", "equals", "Private").count;
+const csv: Breadroll = new Breadroll({ header: true, delimiter: "," });
+const df: Dataframe = await csv.open.local("./data/ds_salaries.csv");
+const filtered = df.filter("job_title", "equals", "Data Scientist").count;
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breadroll",
-  "version": "0.3.4-alpha",
+  "version": "0.3.5-alpha",
   "author": {
     "name": "devsgnr",
     "url": "https://github.com/devsgnr",

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ class Breadroll {
   /**
    * This function opens the seperated value file; gets the table headers (if present)
    * and then also generate the object array and returns the array
-   * @returns { Promise<Array<ObjectType>> }
+   * @returns { BreadrollOpen }
    */
   get open(): BreadrollOpen {
     const local = async (filepath: string): Promise<Dataframe> => {
@@ -42,8 +42,25 @@ class Breadroll {
           throw new Error(err);
         });
     };
+
+    const https = async (url: string, headers?: Headers): Promise<Dataframe> => {
+      const req: Request = new Request(url);
+
+      return await fetch(req, { method: "GET", headers: headers })
+        .then((response: Response) => response.text())
+        .then((value) => {
+          this.parser.get_table_header(value, this.options);
+          this.object = this.parser.generate_object(value, this.options);
+          return this.object;
+        })
+        .catch((err) => {
+          throw new Error(err);
+        });
+    };
+
     return {
       local: local,
+      https: https,
     };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ class Breadroll {
     };
 
     /**
-     * This function fetchs and return a file via a URL over https, with a default `GET` method
+     * This function fetches and return a file via a URL over https, with a default `GET` method
      * read and converts the file to a Dataframe, with provision for optional custom headers
      * @param { string } url
      * @param { Headers } headers

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,14 @@
-/**
- * Breadroll, is a simple lightweight application library for
- * parsing csv, tsv, and other delimited files, performing EDA (exploratory data analysis),
- * and data processing operations on multivariate datasets. Think pandas but written in
- * Typescript and developed on the Bun.js Runtime.
- */
-
 import IO from "./io";
 import Dataframe from "./object";
 import Parser from "./parser";
 import { BreadrollOpen, DataframeReadOptions } from "./types";
 
+/**
+ * breadroll 🥟 is a simple lightweight application library for parsing csv, tsv,
+ * and other delimited files, performing EDA (exploratory data analysis),
+ * and data processing operations on multivariate datasets. Think pandas but written in
+ * Typescript and developed on the [Bun](https://bun.sh) Runtime.
+ */
 class Breadroll {
   private parser: Parser;
   private io: IO;
@@ -30,6 +29,12 @@ class Breadroll {
    * @returns { BreadrollOpen }
    */
   get open(): BreadrollOpen {
+    /**
+     * This function opens the local data source ie. the file on disk, reads it
+     * and converts it to a Dataframe
+     * @param { string } filepath
+     * @returns { Promise<Dataframe> }
+     */
     const local = async (filepath: string): Promise<Dataframe> => {
       return this.io
         .read(filepath)
@@ -43,6 +48,13 @@ class Breadroll {
         });
     };
 
+    /**
+     * This function fetchs and return a file via a URL over https, with a default `GET` method
+     * read and converts the file to a Dataframe, with provision for optional custom headers
+     * @param { string } url
+     * @param { Headers } headers
+     * @returns { Promise<Dataframe> }
+     */
     const https = async (url: string, headers?: Headers): Promise<Dataframe> => {
       const req: Request = new Request(url);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ import Dataframe from "../object";
  */
 type BreadrollOpen = {
   local: (filepath: string) => Promise<Dataframe>;
+  https: (url: string, headers?: Headers) => Promise<Dataframe>;
 };
 
 /**

--- a/test/df.test.ts
+++ b/test/df.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test } from "bun:test";
 import Breadroll from "../src/index";
 import assert from "assert";
 
-// Instanciate DF Class & Open file
+// Instanciate DF Class
 const file = new Breadroll({ header: true, delimiter: "," });
+
+// Open various data sources
 const df = await file.open.local("./test/data/test.csv");
-const remote_https = await file.open.https(
-  "https://firebasestorage.googleapis.com/v0/b/data-entry-fa6df.appspot.com/o/backup%2F2023-10-23T12%3A21%3A12.467Z.csv?alt=media&token=cbccdc42-aa43-4ee4-82fb-7ea5180df918",
-);
+const remote_https = await file.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/main/test/data/test.csv");
 
 /**
  * Testing IO (Input/Output) of none empty file
@@ -62,15 +62,24 @@ describe("testing - dataframe functionality", () => {
 });
 
 /**
- * Testting Remote Data Source - HTTPS
+ * Testing I/O Remote Data Source - HTTPS
  */
 
-describe("testing remote data source - https", () => {
+describe("testing IO remote data source - https", () => {
   /**
    * Test that the remote source retrieve the remote data source
    * via https and then converts to Dataframe and can read out values
    */
-  test("get a remote data source and return Dataframe", () => {
+  test("get a remote data source", () => {
     expect(remote_https.value).toBeTypeOf("object");
+  });
+
+  /**
+   * Test that you can select specific rows of interest in the dataframe
+   * after the dataframe has been returned
+   */
+  test("select specific rows from remote data source", () => {
+    const selected = remote_https.select(["age", "hemo"]);
+    expect(selected.value).toBeTypeOf("object");
   });
 });

--- a/test/df.test.ts
+++ b/test/df.test.ts
@@ -5,7 +5,7 @@ import assert from "assert";
 // Instanciate DF Class
 const file = new Breadroll({ header: true, delimiter: "," });
 
-// Open various data sources
+// Open various data sources - local and remote sources
 const df = await file.open.local("./test/data/test.csv");
 const remote_https = await file.open.https("https://raw.githubusercontent.com/devsgnr/breadroll/main/test/data/test.csv");
 

--- a/test/df.test.ts
+++ b/test/df.test.ts
@@ -5,6 +5,9 @@ import assert from "assert";
 // Instanciate DF Class & Open file
 const file = new Breadroll({ header: true, delimiter: "," });
 const df = await file.open.local("./test/data/test.csv");
+const remote_https = await file.open.https(
+  "https://firebasestorage.googleapis.com/v0/b/data-entry-fa6df.appspot.com/o/backup%2F2023-10-23T12%3A21%3A12.467Z.csv?alt=media&token=cbccdc42-aa43-4ee4-82fb-7ea5180df918",
+);
 
 /**
  * Testing IO (Input/Output) of none empty file
@@ -55,5 +58,19 @@ describe("testing - dataframe functionality", () => {
   test("select return the desired keys", () => {
     const selected = df.select(["class", "age", "hemo", "sc", "al", "bp"]).value[0];
     expect(Object.keys(selected)).toEqual(["class", "age", "hemo", "sc", "al", "bp"]);
+  });
+});
+
+/**
+ * Testting Remote Data Source - HTTPS
+ */
+
+describe("testing remote data source - https", () => {
+  /**
+   * Test that the remote source retrieve the remote data source
+   * via https and then converts to Dataframe and can read out values
+   */
+  test("get a remote data source and return Dataframe", () => {
+    expect(remote_https.value).toBeTypeOf("object");
   });
 });


### PR DESCRIPTION
### Added - `Breadroll.open.https(...)`

This function fetches and return a file via a URL over https, with a default `GET` method, with optional provision for custom headers

Parameter

- `url: string` - the remote location of the file.
- `header?:` [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) - add custom headers to the HTTP request

---

- Fixed Documentation and added documentation for `Breadroll.open.https(...)`
- Setting up automated testing